### PR TITLE
ci: align release/deploy pipeline with socket + buffer (unblocks large-PR deploy + manual dispatch)

### DIFF
--- a/.github/workflows/build-apple.yaml
+++ b/.github/workflows/build-apple.yaml
@@ -21,24 +21,26 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '21'
           cache: gradle
 
       - name: Cache Konan
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.konan
-          key: konan-macos-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts') }}
+          # Keyed on the version catalog only — the konan toolchain tracks the
+          # Kotlin version, not every build.gradle.kts edit.
+          key: konan-macos-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: konan-macos-
 
       - name: Cache Gradle build outputs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.gradle/caches
           key: gradle-macos-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
@@ -55,7 +57,7 @@ jobs:
         run: ./gradlew publishToMavenLocal --no-build-cache ${{ inputs.gradle-args }}
 
       - name: Upload Maven local artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: maven-local-apple
           path: ~/.m2/repository/com/ditchoom

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -21,30 +21,33 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '21'
           cache: gradle
 
       - name: Setup Chrome
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@v2
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
+        uses: android-actions/setup-android@v4
 
       - name: Cache Konan
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.konan
-          key: konan-linux-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts') }}
+          # Keyed on the version catalog only — the konan toolchain tracks the
+          # Kotlin version, not every build.gradle.kts edit — so the cache is
+          # reused across pure build-script changes.
+          key: konan-linux-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: konan-linux-
 
       - name: Cache Gradle build outputs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.gradle/caches
           key: gradle-linux-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
@@ -67,7 +70,7 @@ jobs:
         run: ./gradlew publishToMavenLocal --no-build-cache ${{ inputs.gradle-args }}
 
       - name: Upload Maven local artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: maven-local-linux
           path: ~/.m2/repository/com/ditchoom

--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -4,6 +4,24 @@ on:
     branches: [ main ]
     types:
       - closed
+  workflow_dispatch:
+    inputs:
+      version-bump:
+        description: "Version bump"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      flow:
+        description: "Release flow"
+        type: choice
+        options:
+          - release
+          - draft
+          - dry-run
+        default: release
 
 permissions:
   contents: write
@@ -15,13 +33,13 @@ concurrency:
 jobs:
   check-release:
     name: Check if release is needed
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       flow: ${{ steps.check.outputs.flow }}
       gradle-args: ${{ steps.check.outputs.gradle-args }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Determine release flow
@@ -29,6 +47,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Manual dispatch has no PR to inspect — take flow and version
+          # bump straight from the workflow inputs. Lets us recover from a
+          # failed publish (e.g. transient Central API hiccup, or a merge
+          # whose deploy was blocked) without opening a sham PR to flip the
+          # classifier.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            case "${{ inputs.version-bump }}" in
+              major) echo "gradle-args=-PincrementMajor=true" >> $GITHUB_OUTPUT ;;
+              minor) echo "gradle-args=-PincrementMinor=true" >> $GITHUB_OUTPUT ;;
+              *)     echo "gradle-args=" >> $GITHUB_OUTPUT ;;
+            esac
+            echo "flow=${{ inputs.flow }}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           gradle_args=""
           if ${{ contains(github.event.pull_request.labels.*.name, 'major') }}; then
             gradle_args="-PincrementMajor=true"
@@ -37,17 +70,28 @@ jobs:
           fi
           echo "gradle-args=${gradle_args}" >> $GITHUB_OUTPUT
 
+          # Check for skip-release label
           if ${{ contains(github.event.pull_request.labels.*.name, 'skip-release') }}; then
             echo "flow=dry-run" >> $GITHUB_OUTPUT
             exit 0
           fi
 
+          # Check for draft-release label
           if ${{ contains(github.event.pull_request.labels.*.name, 'draft-release') }}; then
             echo "flow=draft" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          changed_files=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
+          # Check if only non-code files changed.
+          # Use the paginated "list PR files" API rather than `gh pr diff`:
+          # the latter hits the .diff endpoint, which GitHub caps at ~20k
+          # lines / 300 files and returns HTTP 406 for larger PRs (this is
+          # exactly what blocked PR #14's deploy — 373 changed files, diff
+          # rejected, script exited 1). The PR-files API returns objects with
+          # a `filename` field and is paginated, so size-of-change doesn't matter.
+          changed_files=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')
           for file in $changed_files; do
             case "$file" in
               .github/*|*.md|.gitignore|.editorconfig|CLAUDE.md|LICENSE|*.txt)
@@ -103,14 +147,21 @@ jobs:
     if: always() && needs.check-release.outputs.flow != 'skip' && needs.check-release.outputs.flow != 'dry-run'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # Checkout with RELEASE_PAT (workflow scope) so the tag push in
+      # "Create tag and GitHub release" can succeed when the release commit's
+      # tree contains .github/workflows/* changes. Default GITHUB_TOKEN lacks
+      # the workflow scope and silently rejects such tag pushes.
+      # Falls back to GITHUB_TOKEN if RELEASE_PAT is not configured.
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Create draft GitHub release
         if: needs.check-release.outputs.flow == 'draft' && needs.publish.result == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title || 'Manual release' }}
+          PR_URL: ${{ github.event.pull_request.html_url || format('{0}/{1}', github.server_url, github.repository) }}
         run: |
           version="${{ needs.build-linux.outputs.version }}"
           deployment_id="${{ needs.publish.outputs.deployment-id }}"
@@ -140,20 +191,23 @@ jobs:
         if: needs.check-release.outputs.flow == 'release' && needs.publish.result == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title || 'Manual release' }}
+          PR_URL: ${{ github.event.pull_request.html_url || format('{0}/{1}', github.server_url, github.repository) }}
         run: |
           version="${{ needs.build-linux.outputs.version }}"
           tag="v${version}"
 
+          # Check if tag already exists
           if git rev-parse "$tag" >/dev/null 2>&1; then
             echo "Tag $tag already exists, skipping"
             exit 0
           fi
 
+          # Create and push tag
           git tag "$tag"
           git push origin "$tag"
 
+          # Create release
           maven_url="https://central.sonatype.com/artifact/com.ditchoom/mqtt-client/${version}"
           gh release create "$tag" \
               --repo="$GITHUB_REPOSITORY" \

--- a/.github/workflows/publish-to-central.yaml
+++ b/.github/workflows/publish-to-central.yaml
@@ -29,12 +29,16 @@ jobs:
   publish:
     name: "Sign, Bundle & Upload"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Must exceed the "Poll deployment status" ceiling (240 × 30s = 2h) plus the
+    # sign/bundle/upload steps. At 30 the job risks being killed mid-poll while
+    # Central is still PUBLISHING — the deploy would publish itself
+    # (publishingType=AUTOMATIC) but CI would report it as failed. 150 = 2h poll + headroom.
+    timeout-minutes: 150
     outputs:
       deployment-id: ${{ steps.upload.outputs.deployment-id }}
     steps:
       - name: Download merged artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-local-merged
           path: /tmp/maven-repo
@@ -113,7 +117,11 @@ jobs:
         run: |
           TOKEN=$(echo -n "${MAVEN_CENTRAL_USERNAME}:${MAVEN_CENTRAL_PASSWORD}" | base64)
           DEPLOYMENT_ID="${{ steps.upload.outputs.deployment-id }}"
-          MAX_ATTEMPTS=50
+          # 240 × 30s = 2h ceiling. First-time-namespace publications (e.g. a
+          # newly added artifactId under com.ditchoom) sometimes sit in
+          # PUBLISHING for 40+ minutes while Central runs extra validation;
+          # a 50 × 30s = 25min limit timed those out spuriously.
+          MAX_ATTEMPTS=240
           ATTEMPT=0
 
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
@@ -125,7 +133,14 @@ jobs:
               -H "Authorization: Bearer $TOKEN" \
               -H "Content-Type: application/json")
 
-            STATE=$(echo "$STATUS_RESPONSE" | jq -r '.deploymentState // empty')
+            # The Central status endpoint occasionally returns non-JSON: a CDN
+            # error page (HTML), a plain "Origin error" text response, or a
+            # rate-limit body. Without the stderr redirect + empty fallback,
+            # jq's parse-error exit code propagates under `set -e` and kills the
+            # whole step even though Central is still PUBLISHING normally. With
+            # the fallback STATE becomes empty and the "Unable to parse" branch
+            # below handles the transient cleanly — the loop keeps polling.
+            STATE=$(echo "$STATUS_RESPONSE" | jq -r '.deploymentState // empty' 2>/dev/null || true)
 
             if [ -z "$STATE" ]; then
               echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: Unable to parse status response"
@@ -142,7 +157,7 @@ jobs:
                 ;;
               FAILED)
                 echo "Deployment FAILED!"
-                echo "$STATUS_RESPONSE" | jq '.errors // empty'
+                echo "$STATUS_RESPONSE" | jq '.errors // empty' 2>/dev/null || echo "$STATUS_RESPONSE"
                 exit 1
                 ;;
               *)

--- a/.github/workflows/validate-artifacts.yaml
+++ b/.github/workflows/validate-artifacts.yaml
@@ -15,20 +15,40 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Download Linux artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-local-linux
           path: /tmp/linux-repo/com/ditchoom
 
       - name: Download Apple artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-local-apple
           path: /tmp/apple-repo/com/ditchoom
 
+      # Validate the version that was ACTUALLY built into maven-local, not the
+      # workflow input. build-linux's getNextVersion reads Maven Central, and if a
+      # release publishes mid-CI the input version can diverge from the version
+      # build-linux actually stamped onto the artifacts here — then every resolution
+      # below looks for a version that was never published and fails spuriously.
+      # Deriving from the downloaded artifacts is race-proof: we validate whatever
+      # was genuinely built.
+      - name: Resolve built version
+        run: |
+          version=$(ls /tmp/linux-repo/com/ditchoom/mqtt-client/ 2>/dev/null \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1)
+          if [ -z "$version" ]; then
+            echo "::error::No mqtt-client version present in the downloaded maven-local " \
+              "(/tmp/linux-repo/com/ditchoom/mqtt-client/). build-linux's publish didn't produce " \
+              "the artifacts — failing loudly rather than guessing a version to validate."
+            exit 1
+          fi
+          echo "RESOLVED_VERSION=${version}" >> "$GITHUB_ENV"
+          echo "Validating version: ${version} (workflow input was '${{ inputs.version }}')"
+
       - name: Merge artifacts and module metadata
         run: |
-          version="${{ inputs.version }}"
+          version="${RESOLVED_VERSION}"
           LINUX_BASE="/tmp/linux-repo/com/ditchoom"
           APPLE_BASE="/tmp/apple-repo/com/ditchoom"
           MERGED="/tmp/maven-local/com/ditchoom"
@@ -67,7 +87,7 @@ jobs:
           done
 
       - name: Upload merged artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: maven-local-merged
           path: /tmp/maven-local
@@ -75,7 +95,7 @@ jobs:
 
       - name: Validate artifacts
         run: |
-          version="${{ inputs.version }}"
+          version="${RESOLVED_VERSION}"
           FAILED=false
           BASE="/tmp/maven-local/com/ditchoom"
 
@@ -173,7 +193,7 @@ jobs:
           echo "=== ALL VALIDATIONS PASSED ==="
 
       - name: Checkout validation project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .ci/validate-resolution
@@ -181,17 +201,17 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '21'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Validate with Gradle resolution
         run: |
           gradle -p .ci/validate-resolution resolveAll \
-            -PmqttVersion=${{ inputs.version }} \
+            -PmqttVersion=${{ env.RESOLVED_VERSION }} \
             -PmavenRepoPath=/tmp/maven-local \
             --no-daemon


### PR DESCRIPTION
## Why

PR #14's merge did **not** publish 2.0.0: `merged.yaml`'s release gate lists changed files with `gh pr diff --name-only`, whose `.diff` endpoint returns **HTTP 406 above ~300 files**. PR #14 had 373 files → the step aborted → build/validate/publish all skipped. `socket` hit the exact same bug (its PR #48) and already fixed it, so this ports socket's proven deploy chain into mqtt.

## Changes (all `.github/workflows/*` → this PR is classified non-code, so merging it does **not** publish)

**merged.yaml**
- Paginated PR-files API instead of `gh pr diff` — no 300-file cap.
- `workflow_dispatch` trigger (version-bump + flow inputs) — a release can be driven manually; recovers a blocked/failed deploy without a sham PR.
- `checkout@v6`; `RELEASE_PAT` (workflow scope) → `GITHUB_TOKEN` fallback for the finalize tag push; PR title/url fallbacks for manual runs.
- Dropped socket's QUIC-interop-summary job (socket-specific).

**publish-to-central.yaml**
- `timeout` 30→150 min, poll ceiling 50→240 (2h): a 30-min job can be killed mid-poll while Central is still `PUBLISHING` — publishes (AUTOMATIC) but CI red-fails. First-time-namespace artifacts sit in `PUBLISHING` 40+ min.
- Status-poll `jq` guarded against non-JSON Central responses so a transient doesn't kill the step under `set -e`.
- `download-artifact@v8`.

**validate-artifacts.yaml**
- Race-proof **Resolve built version**: derive the version from the downloaded artifacts (not the workflow input), so a release publishing mid-CI can't make validation chase a version that was never built.
- Action bumps: download@v8, upload@v7, checkout@v6, setup-java@v5, setup-gradle@v6.

## After merge
Dispatch **Build Test and Deploy** with `version-bump=major`, `flow=release` to publish **2.0.0** from `main`.

## Note
`RELEASE_PAT` is optional (falls back to `GITHUB_TOKEN`); if it isn't configured, the finalize **tag push** may fail when the release tree contains `.github/workflows/*` changes — the Central publish still succeeds; the `v2.0.0` tag can be added manually.

## Not in scope (follow-up)
`build-linux.yaml` / `build-apple.yaml` action-version bumps + cache-key tweaks, and gradle-setup alignment — the socket versions carry quiche/QUIC/boringssl specifics that need per-line adaptation.