### PR TITLE
ci: fix doubled artifact paths in merged bundle (unblocks 2.0.0 publish)

### DIFF
--- a/.github/workflows/validate-artifacts.yaml
+++ b/.github/workflows/validate-artifacts.yaml
@@ -57,11 +57,20 @@ jobs:
           mkdir -p /tmp/maven-local/com
           cp -r "$LINUX_BASE" /tmp/maven-local/com/
 
-          # Copy Apple per-target artifact directories
+          # Copy Apple per-target artifact directories.
+          # Copy the directory CONTENTS ("$dir".) into the target, never the
+          # directory itself. The macOS host also publishes the cross-platform
+          # publications (-js / -jvm / -android), so those dirs already exist in
+          # the merged tree from the Linux base. `cp -r "$dir" "$MERGED/$name"`
+          # into an existing target NESTS it as com/ditchoom/<a>/<a>/<version>/,
+          # a malformed Maven path that Central Portal validation rejects
+          # ("File path ... is not valid for file ..."). Copying contents merges
+          # in place. See the "no doubled paths" guard below.
           for dir in "$APPLE_BASE"/mqtt-*-*/; do
             [ -d "$dir" ] || continue
             target_name=$(basename "$dir")
-            cp -r "$dir" "$MERGED/$target_name"
+            mkdir -p "$MERGED/$target_name"
+            cp -r "$dir". "$MERGED/$target_name/"
           done
 
           # Merge root module metadata for each module
@@ -85,6 +94,24 @@ jobs:
               echo "WARN: Could not merge $module metadata (linux=$([ -f "$LINUX_MODULE" ] && echo yes || echo no), apple=$([ -f "$APPLE_MODULE" ] && echo yes || echo no))"
             fi
           done
+
+      # Central Portal validates every file's path against its Maven coordinates
+      # and rejects the whole deployment on the first mismatch. Our Gradle
+      # `resolveAll` check only confirms the RIGHT artifacts resolve — it never
+      # sees STRAY/malformed dirs. Catch them here, before the 128MB sign+upload,
+      # instead of after Central rejects the deployment.
+      - name: Assert no malformed (doubled) artifact paths
+        run: |
+          BASE="/tmp/maven-local/com/ditchoom"
+          # A directory nested directly under another of the same name
+          # (com/ditchoom/<a>/<a>/) is the doubled-path signature.
+          STRAY=$(find "$BASE" -type d -regextype posix-extended -regex '.*/([^/]+)/\1$' || true)
+          if [ -n "$STRAY" ]; then
+            echo "::error::Malformed artifact paths (artifactId nested under itself) — Central Portal will reject these:"
+            echo "$STRAY"
+            exit 1
+          fi
+          echo "No doubled/malformed artifact paths in the merged repo."
 
       - name: Upload merged artifacts
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## What & why

The mqtt **2.0.0** release deploy ([run 28758168545](https://github.com/DitchOoM/mqtt/actions/runs/28758168545)) built, signed, bundled, and uploaded fine — then **Central Portal rejected the deployment** during validation:

```
Attempt 1/240: FAILED
Deployment FAILED!
"File path 'com/ditchoom/mqtt-base-models-js/mqtt-base-models-js/2.0.0'
 is not valid for file 'mqtt-base-models-js-2.0.0.module.asc'"
```

Nothing published; no `v2.0.0` tag. This is a **new** failure (unrelated to the earlier `gh pr diff` bug).

## Root cause — the merge, not the build

`build-apple` publishes the cross-platform artifacts (`-js` / `-jvm` / `-android`) *alongside* the Apple klibs, so those module dirs exist in **both** `maven-local-linux` and `maven-local-apple`. The merge in `validate-artifacts.yaml` did:

```bash
cp -r "$dir" "$MERGED/$target_name"
```

`cp -r src dest` when `dest` already exists **nests** `src` inside it → `com/ditchoom/<a>/<a>/<version>/` for all **12** cross-platform module dirs (`{base,4,5,client}-models × {js,jvm,android}`).

**Why CI stayed green:** the doubled dirs are *stray extra copies*; the canonical paths still exist, so `resolveAll` + the metadata/klib checks pass. They only assert the right artifacts **resolve** — never that there are no **malformed** paths. Central validates every file's path and rejects the strays.

## Fix

1. **Merge** — copy directory *contents* (`"$dir".`) into the target instead of the directory, so overlapping dirs merge in place rather than nesting.
2. **Guard** — new `Assert no malformed (doubled) artifact paths` step fails validation *before* the 128 MB sign+upload if any `com/ditchoom/<a>/<a>/` path exists, closing the gap between our resolution check and Central's path validation.

## Verification

Replayed the merge against the **actual failed-run artifacts** (`maven-local-linux` + `maven-local-apple` downloaded from run 28758168545):

| | doubled dirs | guard |
|---|---|---|
| current merge | **12** (incl. `mqtt-base-models-js/mqtt-base-models-js`) | fails ✅ (would catch it) |
| fixed merge | **0**, 68 module dirs = exact union | passes ✅ |

Canonical layout after fix confirmed intact (`mqtt-base-models-js/2.0.0/…module`, Apple klibs at correct depth).

## After merge
Re-dispatch **Build Test and Deploy** (`version-bump=major`, `flow=release`) → still resolves to **2.0.0** (never published, no tag).
